### PR TITLE
Fix modal return to input field

### DIFF
--- a/InputfieldAssistedURL.js
+++ b/InputfieldAssistedURL.js
@@ -25,7 +25,7 @@ $(document).ready(function() {
             var $i = $iframe.contents();
             var $a = $($("#link_markup", $i).text());
 
-						$(opener).siblings('.InputfieldAssistedUrlText').find('.InputfieldAssistedURLInput').val($a.attr('href'));
+            $(opener).siblings('.InputfieldAssistedUrlText').find('.InputfieldAssistedURLInput').val($a.attr('href'));
 
             $iframe.dialog("close");
         }

--- a/InputfieldAssistedURL.js
+++ b/InputfieldAssistedURL.js
@@ -25,7 +25,7 @@ $(document).ready(function() {
             var $i = $iframe.contents();
             var $a = $($("#link_markup", $i).text());
 
-            $(opener).siblings('input').val($a.attr('href'));
+						$(opener).siblings('.InputfieldAssistedUrlText').find('.InputfieldAssistedURLInput').val($a.attr('href'));
 
             $iframe.dialog("close");
         }

--- a/InputfieldAssistedURL.module
+++ b/InputfieldAssistedURL.module
@@ -55,7 +55,7 @@ class InputfieldAssistedURL extends Inputfield
         $field = new InputfieldURL();
         $field->set('name', $this->attr('name'));
         $field->set('value', $this->attr('value'));
-        $field->set('class', 'InputfieldAssistedURL');
+        $field->set('class', 'InputfieldAssistedURLInput');
 
         $btn = $this->modules->get('InputfieldButton');
         $btn->attr('id', $this->attr('name') . "_assistedurl_open");


### PR DESCRIPTION
The recent styling changes in #3 broke the modal dialog from returning the chosen link value back to the input.

This PR should fix it.

Hope that helps
